### PR TITLE
package naming issue with centos6

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ end
 package "libmemcache-dev" do
   case node[:platform]
   when "redhat","centos","fedora"
-    package_name "libmemcache-devel"
+    package_name "libmemcached-devel"
   else
     package_name "libmemcache-dev"
   end


### PR DESCRIPTION
I needed to make this change for centos 6 to work.  I have not tested that it is backwards compatible with centos 5.
