### PR TITLE
[COOK-1764] - Add Max Connections to memcached.conf and fix typos

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
-default[:memcached][:memory] = 64
-default[:memcached][:port] = 11211
-default[:memcached][:user] = "nobody"
-default[:memcached][:listen] = "0.0.0.0"
+default[:memcached][:memory]  = 64
+default[:memcached][:port]    = 11211
+default[:memcached][:user]    = "nobody"
+default[:memcached][:listen]  = "0.0.0.0"
 default[:memcached][:maxconn] = "1024"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,6 +62,7 @@ else
     :listen => node[:memcached][:listen],
     :user => node[:memcached][:user],
     :port => node[:memcached][:port],
+    :maxconn => node[:memcached][:maxconn],
     :memory => node[:memcached][:memory]
   )
   notifies :restart, resources(:service => "memcached"), :immediately

--- a/templates/default/memcached.conf.erb
+++ b/templates/default/memcached.conf.erb
@@ -1,10 +1,10 @@
 #
-# Configured by Chef. Logcal changes will be lost.
+# Configured by Chef. Local changes will be lost.
 #
 # memcached default config file
 # 2003 - Jay Bonci <jaybonci@debian.org>
 # This configuration file is read by the start-memcached script provided as
-# part of the Debian GNU/Linux distribution. 
+# part of the Debian GNU/Linux distribution.
 
 # Run memcached as a daemon. This command is implied, and is not needed for the
 # daemon to run. See the README.Debian that comes with this package for more
@@ -38,7 +38,7 @@ logfile /var/log/memcached.log
 -l <%= @listen %>
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
-# -c 1024
+-c <%= @maxconn %>
 
 # Lock down all paged memory. Consult with the README and homepage before you do this
 # -k

--- a/templates/default/memcached.sysconfig.erb
+++ b/templates/default/memcached.sysconfig.erb
@@ -1,5 +1,5 @@
 #
-# Configured by Chef. Logcal changes will be lost.
+# Configured by Chef. Local changes will be lost.
 #
 # "Javier Frias"<jfrias@gmail.com>
 #


### PR DESCRIPTION
This commit adds the maxconn attribute to the memcached.conf.erb
template. This commit also fixes typos in some of the template files.
