### PR TITLE
[COOK-2790] Add attribute for maximum object size

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ service.
 * `memcached['user']` - user to run memcached as.
 * `memcached['port']` - port for memcached to listen on.
 * `memcached['listen']` - IP address for memcached to listen on.
+* `memcached['maxconn']` - maximum number of connections to accept (defaults to 1024)
+* `memcached['max_object_size']` - maximum size of an object to cache (defaults to 1MB)
 
 Usage
 =====

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default['memcached']['memory'] = 64
 default['memcached']['port'] = 11211
 default['memcached']['listen'] = "0.0.0.0"
 default['memcached']['maxconn'] = 1024
+default['memcached']['max_object_size'] = "1m"
 case node['platform_family']
 when 'suse', 'fedora', 'rhel'
   default['memcached']['user'] = 'memcached'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -84,7 +84,8 @@ else
       :user => node['memcached']['user'],
       :port => node['memcached']['port'],
       :maxconn => node['memcached']['maxconn'],
-      :memory => node['memcached']['memory']
+      :memory => node['memcached']['memory'],
+      :max_object_size => node['memcached']['max_object_size']
     )
     notifies :restart, "service[memcached]"
   end

--- a/templates/default/memcached.conf.erb
+++ b/templates/default/memcached.conf.erb
@@ -48,3 +48,6 @@ logfile /var/log/memcached.log
 
 # Maximize core file limit
 # -r
+
+# Max object size
+-I <%= @max_object_size %>


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2790

Default to 1M in the attribute, which is the default for memcached.
This feature requires version 1.4.2, which is satifisfied in Ubuntu 10.04-current and RHEL 5 to current.  It's been out for a while so this should really be on any mildly modern OS.
