### PR TITLE
Bug fixed: cookbooks/memcached/recipes/default.rb:67:in `block in from_file': undefined method `[]' for nil:NilClass

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,7 +64,7 @@ when "rhel", "fedora", "suse"
       :port => node['memcached']['port'],
       :maxconn => node['memcached']['maxconn'],
       :memory => node['memcached']['memory'],
-      :logfilename => node['memcached-chat']['logfilename']
+      :logfilename => node['memcached']['logfilename']
     )
     notifies :restart, "service[memcached]"
   end


### PR DESCRIPTION
The typo fixed, because otherwise the include_recipe "memcached" without overriden node.override["memcached-chat"]["logfilename"] node parameter does not work properly and raises an error .
