### PR TITLE
[COOK-3336] Fix spelling error in logfilename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@ memcached Cookbook CHANGELOG
 ============================
 This file is used to list changes made in each version of the memcached cookbook.
 
-v1.5.1
-### Bug
-- **[COOK-3336](https://tickets.opscode.com/browse/COOK-3336)** - Fixed spelling error in logfile attribute
-
 v1.5.0
 ------
 ### Improvement

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs memcached and provides a define to set up an instance of memcache via runit"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.5.1"
+version           "1.5.0"
 depends           "runit", "~> 1.0"
 depends           "yum"
 


### PR DESCRIPTION
One of the attribute names were misspelled :) 
