### PR TITLE
Fix logfilename reference to prevent error

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,7 +64,7 @@ when "rhel", "fedora", "suse"
       :port => node['memcached']['port'],
       :maxconn => node['memcached']['maxconn'],
       :memory => node['memcached']['memory'],
-      :logfilename => node['memcached-chat']['logfilename']
+      :logfilename => node['memcached']['logfilename']
     )
     notifies :restart, "service[memcached]"
   end


### PR DESCRIPTION
Looks like a copy/paste error causes this to reference a node "memcached-chat" that doesn't actually exist.  It causes the error:

"undefined method `[]' for nil:NilClass"

Not worth my effort to accept your rights-assignments document so feel free to reject this pull request and remove the 5 characters yourself (I'd have just filed a bug but you have that feature disabled).
