### PR TITLE
Added 'ignore_failure true' for libmemcache-dev

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,7 @@ package "libmemcache-dev" do
   else
     package_name "libmemcache-dev"
   end
+  ignore_failure true
   action :install
 end
 


### PR DESCRIPTION
to avoid failure on RHEL 6.2 with empty redhat.repo
libmemcache-dev should be optional anyway, it's not necessary to run memcached
