### PR TITLE
Restore Chef Infra Client < 16 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to list changes made in each version of the memcached cookbook
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- Restore Chef Infra Client < 16 compatibility
+
 ## 6.0.1 - 2020-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Provides a custom resource for installing instances of memcached. Also ships wit
 - RHEL and derivatives
 - Fedora
 
-### Chef
+### Chef Infra Client
 
-- Chef 13+
+- Chef Infra Client 13+
 
 ## Attributes
 

--- a/resources/memcached_instance.rb
+++ b/resources/memcached_instance.rb
@@ -3,7 +3,7 @@
 # resource:: memcached_instance
 #
 # Author:: Tim Smith <tsmith@chef.io>
-# Copyright:: 2016, Chef Software, Inc.
+# Copyright:: 2016-2020, Chef Software, Inc.
 # Copyright:: 2020, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@
 #
 include Memcached::Helpers
 
+resource_name :memcached_instance
 provides :memcached_instance
 provides :memcached_instance_systemd # legacy name
 


### PR DESCRIPTION
Chef Infra Client 16 needs provides and Chef Infra Client < 16 needs resource_name here. If we support both then we need both.

Signed-off-by: Tim Smith <tsmith@chef.io>