### PR TITLE
Remove unused lock_dir method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,16 @@ jobs:
     strategy:
       matrix:
         os:
-          - "debian-9"
-          - "debian-10"
-          - "amazonlinux-2"
-          - "centos-7"
-          - "centos-8"
-          - "centos-stream-8"
-          - "ubuntu-1804"
+          - "almalinux-8"
+          - "almalinux-9"
+          - "amazonlinux-2023"
+          - "debian-11"
+          - "debian-12"
+          - "rockylinux-8"
+          - "rockylinux-9"
           - "ubuntu-2004"
+          - "ubuntu-2204"
+          - "ubuntu-2404"
         suite:
           - "default"
           - "instance"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-Standardise files with files in sous-chefs/repo-management
-
-Standardise files with files in sous-chefs/repo-management
-
-Standardise files with files in sous-chefs/repo-management
+- Remove unused `lock_dir` method
+- Standardise files with files in sous-chefs/repo-management
+- Update test CI platforms
 
 ## 7.0.25 - *2024-05-02*
 
@@ -297,16 +295,16 @@ Standardise files with files in sous-chefs/repo-management
 
 ## [1.6.0] - 2013-10-04
 
-- [COOK-3682](https://tickets.chef.io/browse/COOK-3682) - Set user when using Debian packages
-- [COOK-3336](https://tickets.chef.io/browse/COOK-3336) - Add an option to specify the logfile (fix)
+- [COOK-3682]: Set user when using Debian packages
+- [COOK-3336]: Add an option to specify the logfile (fix)
 
 ## [1.5.0] - 2013-08-28
 
-- [COOK-3336](https://tickets.chef.io/browse/COOK-3336) - Option to specify logfile
-- [COOK-2790](https://tickets.chef.io/browse/COOK-2790) - Support for defining max object size
+- [COOK-3336]: Option to specify logfile
+- [COOK-2790]: Support for defining max object size
 
-- [COOK-3299](https://tickets.chef.io/browse/COOK-3299) - Document that `memcached` is exposed by default
-- [COOK-2990](https://tickets.chef.io/browse/COOK-2990) - Include `listen`, `maxconn`, and `user` in the runit service
+- [COOK-3299]: Document that `memcached` is exposed by default
+- [COOK-2990]: Include `listen`, `maxconn`, and `user` in the runit service
 
 ## [1.4.0] - 2013-05-23
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,14 +15,16 @@ verifier:
   name: inspec
 
 platforms:
-  - name: debian-9
-  - name: debian-10
-  - name: amazonlinux-2
-  - name: centos-7
-  - name: centos-8
-  - name: centos-stream-8
-  - name: ubuntu-18.04
+  - name: almalinux-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
+  - name: debian-11
+  - name: debian-12
+  - name: rockylinux-8
+  - name: rockylinux-9
   - name: ubuntu-20.04
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: default

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,13 +23,6 @@ module Memcached
       )
     end
 
-    def lock_dir
-      value_for_platform_family(
-        %w(rhel fedora suse amazon) => '/var/lock/subsys',
-        'default' => '/var/lock'
-      )
-    end
-
     # if the instance name is memcached don't spit out memcached_memcached
     def memcached_instance_name
       new_resource.instance_name == 'memcached' ? 'memcached' : "memcached_#{new_resource.instance_name}"


### PR DESCRIPTION
This conflicts with a method with the same name in the apache2 cookbook which
has been causing some idempotency issues when used together. It seems this
method is no longer being used so it's safe to remove.

In addition, update test CI platforms.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
