### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Cinc Workstation
         uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Limitations
+# Agent Notes
 
 ## Package Availability
 
@@ -44,6 +44,13 @@ source.
 
 * The built-in proxy requires compiling memcached from source with proxy support enabled.
 * The `memcached_instance` resource assumes systemd-managed Linux services.
+
+## Policyfile Migration
+
+* Dependency resolution is managed by `Policyfile.rb`; do not reintroduce Berkshelf files.
+* Kitchen suites use Policyfile named run lists for the `test::default` and `test::instance`
+  recipes.
+* ChefSpec loads `chefspec/policyfile`.
 
 ## Research Sources
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+name 'memcached'
+
+run_list 'test::default'
+
+cookbook 'memcached', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+%w(default instance).each do |recipe_name|
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
@@ -13,6 +13,7 @@ provisioner:
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -36,12 +37,6 @@ platforms:
   - name: ubuntu-22.04
   - name: ubuntu-24.04
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-  instance: &instance_run_list
-    - recipe[test::instance]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -52,8 +47,10 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier
   - name: instance
-    run_list: *instance_run_list
+    provisioner:
+      named_run_list: instance
     verifier: *instance_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 shared_context 'memcached_stubs' do
   before do


### PR DESCRIPTION
## Description

Migrate dependency resolution from Berkshelf to Policyfile.

## Changes

* Add `Policyfile.rb` with named run lists for the `default` and `instance` suites.
* Remove `Berksfile`.
* Rename `LIMITATIONS.md` to `AGENTS.md` and add Policyfile migration notes.
* Switch ChefSpec setup from `chefspec/berkshelf` to `chefspec/policyfile`.
* Configure Kitchen to use `policyfile_zero` and per-suite `named_run_list`.
* Update Copilot setup to run `chef install Policyfile.rb`.

## Validation

* `chef install Policyfile.rb` - passed
* `ruby -c Policyfile.rb` - passed
* `cookstyle` - passed, 14 files inspected, no offenses
* `env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation` - passed, 36 examples, 0 failures
* `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list` - passed
* `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose default-ubuntu-2404` - passed; confirmed `policyfile: Policyfile.rb` and `named_run_list: default`
* `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always` - passed, 3 controls / 7 tests successful
* `git diff --check` - passed
* `actionlint` - passed
* `yamllint .` - passed
* `markdownlint-cli2 "**/*.md" "#CHANGELOG.md"` - passed

Note: plain `chef exec rspec --format documentation` fails locally before loading specs because the Workstation Ruby process picks up `/Users/damacus/.chef/gem/ruby/3.1.0/gems/json-2.20.0`, whose native extension has a macOS code-signing Team ID mismatch. Running RSpec with `GEM_HOME` and `GEM_PATH` isolated to the Chef Workstation embedded gem path passes.
